### PR TITLE
provided example of exporting pages to png/svg

### DIFF
--- a/src/actions/export-layers-action.js
+++ b/src/actions/export-layers-action.js
@@ -7,7 +7,7 @@ var GAction = GravitDesigner.GAction;
 var ExportDialog = require('./export-layers-action/exportdialog.js');
 
 /**
- * Action for counting the number of selected elements
+ * Action for export page layers to png/svg
  * @class ExportLayersAction
  * @extends GAction
  * @constructor
@@ -37,7 +37,7 @@ ExportLayersAction.prototype.getTitle = function () {
  */
 ExportLayersAction.prototype.getCategory = function () {
     //the menu category the action will be placed on
-    return 'starter-plugin';
+    return 'Export';
 };
 
 /**

--- a/src/actions/export-layers-action.js
+++ b/src/actions/export-layers-action.js
@@ -1,0 +1,74 @@
+//GravitDesigner is the global variable that contains all Gravit Designer classes and functions to be used on your plugin
+var GObject = GravitDesigner.framework.core.GObject;
+var GAction = GravitDesigner.GAction;
+
+//require works on plugins, just require any js file that you created using the
+//relative path
+var ExportDialog = require('./export-layers-action/exportdialog.js');
+
+/**
+ * Action for counting the number of selected elements
+ * @class ExportLayersAction
+ * @extends GAction
+ * @constructor
+ */
+function ExportLayersAction() {
+};
+//GObject.inherit is used to inherit code from other js class
+GObject.inherit(ExportLayersAction, GAction);
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.getId = function () {
+    //id of the action, can be used to trigger actions without user interaction
+    return 'export.layers';
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.getTitle = function () {
+    return 'Export Layers';
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.getCategory = function () {
+    //the menu category the action will be placed on
+    return 'starter-plugin';
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.getGroup = function () {
+    //the group inside a category. If two actions have same category but
+    //different group, a separator will be placed between them
+    return 'action';
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.getShortcut = function () {
+    return null;
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.isEnabled = function () {
+    return gDesigner.getActiveDocument() !== null;
+};
+
+/**
+ * @override
+ */
+ExportLayersAction.prototype.execute = function () {
+    //when the action is executed, open the export dialog we created
+    new ExportDialog().open();
+};
+
+module.exports = ExportLayersAction;

--- a/src/actions/export-layers-action/exportdialog.css
+++ b/src/actions/export-layers-action/exportdialog.css
@@ -1,0 +1,20 @@
+.g-export-layers-dialog > div > div:first-child {
+    margin-bottom: 10px; 
+}
+
+.g-export-layers-dialog div div {
+    display: flex;
+}
+
+.g-export-layers-dialog > div > div > div {
+    min-width: 45px;
+}
+
+.g-export-layers-dialog span {
+    align-self: center;
+}
+
+.g-export-layers-dialog select {
+    margin-left: 10px;
+    min-width: 120px;
+}

--- a/src/actions/export-layers-action/exportdialog.js
+++ b/src/actions/export-layers-action/exportdialog.js
@@ -1,0 +1,107 @@
+var GPage = GravitDesigner.framework.core.GPage;
+var GElement = GravitDesigner.framework.core.GElement;
+var GExporter = GravitDesigner.GExporter;
+
+var SVG = 0;
+var PNG = 1;
+
+var ACTIVE_PAGE = 0;
+var ALL_PAGES = 1;
+
+class ExportDialog {
+    constructor() {
+        var formatDiv = $('<div/>')
+            .append($('<div/>')
+                .append($('<span/>')
+                    .text('Format')))
+            .append($('<select/>')
+                .attr('data-property', 'format')
+                .append($('<option/>')
+                    .text('SVG')
+                    .data('option', SVG))
+                .append($('<option/>')
+                    .text('PNG')
+                    .data('option', PNG)));
+        
+        var pagesDiv = $('<div/>')
+            .append($('<div/>')
+                .append($('<span/>')
+                    .text('Pages')))
+            .append($('<select/>')
+                .attr('data-property', 'pages')
+                .append($('<option/>')
+                    .text('Current page')
+                    .data('option', ACTIVE_PAGE))
+                .append($('<option/>')
+                    .text('All pages')
+                    .data('option', ALL_PAGES)));
+        
+        this._dialog = $('<div></div>')
+            .append(formatDiv)
+            .append(pagesDiv);
+
+        //gDialog is a jquery plugin that allows creating of ready-to-use dialogs
+        this._dialog.gDialog({
+            //custom class for the dialog, useful to custom css
+            className: 'g-export-layers-dialog',
+            //the buttons available on the dialog
+            buttons: [
+                $('<button>Cancel</button>').on('click', () => this.close()),
+                $('<button>Export</button>').on('click', () => {
+                    this._exportLayers();
+                    this.close();
+                })
+            ]
+        });
+    }
+    
+    _exportLayers() {
+        //use simple jquery to get values of selectors
+        var format = this._dialog.find('[data-property="format"]').find('option:selected').data('option');
+        var page = this._dialog.find('[data-property="pages"]').find('option:selected').data('option');
+        
+        var pages = [];
+        
+        //scene is the object that contains all pages, elements, etc of a document
+        //we can retrieve the current document using global variable gDesigner like below
+        var scene = gDesigner.getActiveDocument().getScene();
+        
+        if (page === ACTIVE_PAGE) {
+            //if only exporting active page, we can just get the active page of the document scene
+            pages.push(scene.getActivePage());
+        } else {
+            //if exporting all pages, we can iterate through the scene children and 
+            //add the ones that are instance of GPage
+            for (var child = scene.getLastChild(); child !== null; child = child.getPrevious()) {
+                if (child instanceof GPage) {
+                    pages.push(child);
+                }
+            }
+        }
+        
+        //here we define the format that the layers will be exported
+        var settings = {'format': format === SVG ? 'svg' : 'png'};
+        
+        //let's use GExporter class to generate the exportable layers and pages of our selection
+        //pages contains all pages that must be exported
+        //settings contains the format that the layers should be exported
+        //true will set the exporter to export all children of the element being exported
+        var exportables = GExporter.generateExportables(pages, settings, true);
+        
+        //finally, export the pages. Also provides the storage used to save the exported files (necessary for cross-platform exporting)
+        GExporter.export(exportables, gDesigner.getActiveDocument().getStorage() || gDesigner.getDefaultStorage(), gDesigner.getActiveDocument().getTitle());
+    }
+
+    open() {
+        //open the current dialog. True allows the user to close the dialog by clicking somewhere else on the screen
+        this._dialog.gDialog('open', true);
+    }
+
+    close() {
+        //closes the dialog
+        this._dialog.gDialog('close');
+    }
+};
+
+module.exports = ExportDialog;
+

--- a/src/main.js
+++ b/src/main.js
@@ -1,10 +1,19 @@
 var CountSelectionAction = require('./actions/count-selection-action');
+var ExportLayersAction = require('./actions/export-layers-action');
 
 // This is the main entry point to your plugin called by the designer when he is ready
 module.exports = {
     init: function (gravit) {
     	//we can push new actions to gravit.actions! This actions will be added to the taskbar
-        gravit.actions.push(new CountSelectionAction());
+        //gravit.actions.push(new CountSelectionAction());
+        gravit.actions.push(new ExportLayersAction());
     },
-    start: function () {}
+    start: function () {
+        //on start, we can add custom css files, like the css for the export dialog
+        var link = document.createElement('link');
+        link.setAttribute('rel', 'stylesheet');
+        link.setAttribute('type', 'text/css');
+        link.setAttribute('href', process.cwd() + '/src/actions/export-layers-action/exportdialog.css');
+        document.getElementsByTagName('head')[0].appendChild(link);
+    }
 };


### PR DESCRIPTION
for version 3.1.1, GExporter is still not available on the plugin architecture. As a workaround, the following file can be edited: 

> $project_folder/node_modules/gravit-designer/designer.electron.js

and the sequence:

> GCategory:i(8)

should be replaced by:

> GCategory:i(8),GExporter:i(486)

on next update of the plugin architecture, this will not be needed anymore